### PR TITLE
Create automatic releases from CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         cd ".\.trex"
         Get-ChildItem -Path "..\NvRemixBridge.*" | Move-Item
         cd "..\.."
-        Compress-Archive -Path ".\_upload\*" -DestinationPath "bridge-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}.zip"
+        Compress-Archive -Path ".\_upload\*" -DestinationPath "bridge-remix-${{github.run_number}}-${{env.GITHUB_SHA_SHORT}}-${{matrix.build-flavour}}.zip"
 
     - name: "Prune automatic releases to latest"
       uses: dev-drprasad/delete-older-releases@v0.2.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, automatic-releases ]
   pull_request:
     branches: [ main ]
 
@@ -55,3 +55,36 @@ jobs:
           _output\.trex\*.dll
           _output\.trex\*.exe
           _output\.trex\*.pdb
+      
+      name: Create clean directory for CI/CD release 
+      shell: pwsh
+      run: |
+        New-Item ".\_upload" -Type Directory
+        cd ".\_upload"
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.pdb | Copy-Item
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.dll | Copy-Item
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.exe | Copy-Item
+        New Item ".\.trex" -Type Directory
+        cd ".\.trex"
+        Get-ChildItem -Path "..\NvRemixBridge.*" | Move-Item
+        cd "..\.."
+        Compress-Archive -Path ".\_upload\*" -DestinationPath "bridge-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}.zip"
+
+    - name: "Prune automatic CI/CD releases to latest"
+      uses: dev-drprasad/delete-older-releases@v0.2.1
+      with:
+        keep_latest: 3
+        delete_tag_pattern: automatic # defaults to ""
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Create new CI/CD release"
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{ secrets.GITHUB_TOKEN }}"
+        automatic_release_tag: "automatic-${{matrix.build-flavour}}"
+        prerelease: true
+        title: "bridge-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
+        files: | 
+          *.zip
+          _release/*.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   build-windows:
     runs-on: windows-2022
-    permissions: write-all
+    permissions: 
+      contents: write
 
     strategy:
       matrix:
@@ -86,7 +87,7 @@ jobs:
         tag_name: "automatic-${{matrix.build-flavour}}"
         prerelease: true
         generate_release_notes: true
-        title: "bridge-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
+        name: "bridge-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
         files: | 
           *.zip
           _upload/*.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ main, automatic-releases ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         tag_name: "automatic-${{matrix.build-flavour}}"
         prerelease: true
         generate_release_notes: true
-        name: "bridge-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
+        name: "bridge-remix-automatic-${{matrix.build-flavour}}"
         files: | 
           *.zip
           _upload/*.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,7 @@ on:
 jobs:
   build-windows:
     runs-on: windows-2022
-    permissions:
-      contents: write-all
+    permissions: write-all
 
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,12 +80,13 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: "Create new CI/CD release"
-      uses: "marvinpinto/action-automatic-releases@latest"
+      uses: softprops/action-gh-release@v1
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "automatic-${{matrix.build-flavour}}"
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        tag_name: "automatic-${{matrix.build-flavour}}"
         prerelease: true
+        generate_release_notes: true
         title: "bridge-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}"
         files: | 
           *.zip
-          _release/*.txt
+          _upload/*.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         cd "..\.."
         Compress-Archive -Path ".\_upload\*" -DestinationPath "bridge-remix-${{env.GITHUB_SHA_SHORT}}-${{github.run_number}}-${{matrix.build-flavour}}.zip"
 
-    - name: "Prune automatic CI/CD releases to latest"
+    - name: "Prune automatic releases to latest"
       uses: dev-drprasad/delete-older-releases@v0.2.1
       with:
         keep_latest: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         Get-ChildItem -Path "..\_output" -Recurse -Filter *.pdb | Copy-Item
         Get-ChildItem -Path "..\_output" -Recurse -Filter *.dll | Copy-Item
         Get-ChildItem -Path "..\_output" -Recurse -Filter *.exe | Copy-Item
-        New Item ".\.trex" -Type Directory
+        New-Item ".\.trex" -Type Directory
         cd ".\.trex"
         Get-ChildItem -Path "..\NvRemixBridge.*" | Move-Item
         cd "..\.."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           _output\.trex\*.exe
           _output\.trex\*.pdb
       
-      name: Create clean directory for CI/CD release 
+    - name: Create clean directory for CI/CD release 
       shell: pwsh
       run: |
         New-Item ".\_upload" -Type Directory

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-windows:
     runs-on: windows-2022
+    permissions:
+      contents: write-all
 
     strategy:
       matrix:


### PR DESCRIPTION
The following PR addresses a complaint from users that artifacts from GitHub actions are hard to access through scripts.  This would create three releases that are built and shipped on push, and on subsequent pushes additional builds are provided on the same automatic release page.  This approach will allow for ease of access to builds without a GitHub login while minimizing the potential clutter of such a solution.

This approach also allows for setting a dedicated URL for uploads as an output; however, this has not been configured yet.