### PR TITLE
Automatic releases on build, smaller downloads for artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-windows:
     runs-on: windows-2022
+    permissions: 
+      contents: write
 
     strategy:
       matrix:
@@ -55,3 +57,37 @@ jobs:
           _output\.trex\*.dll
           _output\.trex\*.exe
           _output\.trex\*.pdb
+      
+    - name: Create clean directory for CI/CD release 
+      shell: pwsh
+      run: |
+        New-Item ".\_upload" -Type Directory
+        cd ".\_upload"
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.pdb | Copy-Item
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.dll | Copy-Item
+        Get-ChildItem -Path "..\_output" -Recurse -Filter *.exe | Copy-Item
+        New-Item ".\.trex" -Type Directory
+        cd ".\.trex"
+        Get-ChildItem -Path "..\NvRemixBridge.*" | Move-Item
+        cd "..\.."
+        Compress-Archive -Path ".\_upload\*" -DestinationPath "bridge-remix-${{github.run_number}}-${{env.GITHUB_SHA_SHORT}}-${{matrix.build-flavour}}.zip"
+
+    - name: "Prune automatic releases to latest"
+      uses: dev-drprasad/delete-older-releases@v0.2.1
+      with:
+        keep_latest: 3
+        delete_tag_pattern: automatic # defaults to ""
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Create new CI/CD release"
+      uses: softprops/action-gh-release@v1
+      with:
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        tag_name: "automatic-${{matrix.build-flavour}}"
+        prerelease: true
+        generate_release_notes: true
+        name: "bridge-remix-automatic-${{matrix.build-flavour}}"
+        files: | 
+          *.zip
+          _upload/*.txt


### PR DESCRIPTION
The following PR addresses a complaint from users that artifacts from GitHub actions are hard to access through scripts. This would create three releases that are built and shipped on push, and on subsequent pushes additional builds are provided on the same automatic release page. This approach will allow for ease of access to builds without a GitHub login while minimizing the potential clutter of such a solution.

It also significantly reduces the file size of uploads, and uploads are sorted properly when organized from A-Z; if desired, these improvements can be applied to the actions artifacts as well.