### PR TITLE
BridgeApi - RemixApi wrapper for x86 games

### DIFF
--- a/bridge.conf
+++ b/bridge.conf
@@ -87,6 +87,14 @@
 # client.enableDpiAwareness = True
 
 
+# Exposes the RemixApi to the client allowing 32-bit games 
+# to use parts of the RemixApi.
+#
+# Supported values: True, False
+
+# client.exposeRemixApi = False
+
+
 #
 # Server Settings
 #

--- a/src/api/remix_api/bridge_c.h
+++ b/src/api/remix_api/bridge_c.h
@@ -1,0 +1,404 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+// Bridge API header for both the x86 bridge client and the x86 game
+
+#ifndef BRIDGE_C_H_
+#define BRIDGE_C_H_
+
+#include <cstdint>
+#include <windows.h>
+
+#define BRIDGEAPI_CALL __stdcall
+#define BRIDGEAPI_PTR  BRIDGEAPI_CALL
+
+#ifdef BRIDGE_API_IMPORT
+    #define BRIDGE_API  __declspec(dllimport)
+#else
+    #define BRIDGE_API  __declspec(dllexport)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+  typedef enum bridgeapi_ErrorCode {
+    BRIDGEAPI_ERROR_CODE_SUCCESS = 0,
+    BRIDGEAPI_ERROR_CODE_GENERAL_FAILURE = 1,
+    // WinAPI's GetModuleHandle has failed
+    BRIDGEAPI_ERROR_CODE_GET_MODULE_HANDLE_FAILURE = 2,
+    BRIDGEAPI_ERROR_CODE_INVALID_ARGUMENTS = 3,
+    // Couldn't find 'remixInitialize' function in the .dll
+    BRIDGEAPI_ERROR_CODE_GET_PROC_ADDRESS_FAILURE = 4,
+    // CreateD3D9 / RegisterD3D9Device can be called only once
+    BRIDGEAPI_ERROR_CODE_ALREADY_EXISTS = 5,
+    // RegisterD3D9Device requires the device that was created with IDirect3DDevice9Ex, returned by CreateD3D9
+    BRIDGEAPI_ERROR_CODE_REGISTERING_NON_REMIX_D3D9_DEVICE = 6,
+    // RegisterD3D9Device was not called
+    BRIDGEAPI_ERROR_CODE_REMIX_DEVICE_WAS_NOT_REGISTERED = 7,
+    BRIDGEAPI_ERROR_CODE_INCOMPATIBLE_VERSION = 8,
+    // WinAPI's SetDllDirectory has failed
+    //BRIDGEAPI_ERROR_CODE_SET_DLL_DIRECTORY_FAILURE = 9,
+    // WinAPI's GetFullPathName has failed
+    //BRIDGEAPI_ERROR_CODE_GET_FULL_PATH_NAME_FAILURE = 10,
+    BRIDGEAPI_ERROR_CODE_NOT_INITIALIZED = 11,
+  } BRIDGEAPI_ErrorCode;
+
+  // ------------------------------------------
+  // <- remix api types from the remix_c header
+
+  typedef enum remixapi_StructType {
+    REMIXAPI_STRUCT_TYPE_NONE = 0,
+    REMIXAPI_STRUCT_TYPE_INITIALIZE_LIBRARY_INFO = 1,
+    REMIXAPI_STRUCT_TYPE_MATERIAL_INFO = 2,
+    REMIXAPI_STRUCT_TYPE_MATERIAL_INFO_PORTAL_EXT = 3,
+    REMIXAPI_STRUCT_TYPE_MATERIAL_INFO_TRANSLUCENT_EXT = 4,
+    REMIXAPI_STRUCT_TYPE_MATERIAL_INFO_OPAQUE_EXT = 5,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO = 6,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_DISTANT_EXT = 7,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_CYLINDER_EXT = 8,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_DISK_EXT = 9,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_RECT_EXT = 10,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_SPHERE_EXT = 11,
+    REMIXAPI_STRUCT_TYPE_MESH_INFO = 12,
+    REMIXAPI_STRUCT_TYPE_INSTANCE_INFO = 13,
+    REMIXAPI_STRUCT_TYPE_INSTANCE_INFO_BONE_TRANSFORMS_EXT = 14,
+    REMIXAPI_STRUCT_TYPE_INSTANCE_INFO_BLEND_EXT = 15,
+    REMIXAPI_STRUCT_TYPE_CAMERA_INFO = 16,
+    REMIXAPI_STRUCT_TYPE_CAMERA_INFO_PARAMETERIZED_EXT = 17,
+    REMIXAPI_STRUCT_TYPE_MATERIAL_INFO_OPAQUE_SUBSURFACE_EXT = 18,
+    REMIXAPI_STRUCT_TYPE_INSTANCE_INFO_OBJECT_PICKING_EXT = 19,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_DOME_EXT = 20,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_USD_EXT = 21,
+    REMIXAPI_STRUCT_TYPE_STARTUP_INFO = 22,
+    REMIXAPI_STRUCT_TYPE_PRESENT_INFO = 23,
+    // NOTE: if adding a new struct, register it in 'rtx_remix_specialization.inl'
+  } remixapi_StructType;
+
+  namespace x86
+  {
+    typedef uint32_t remixapi_Bool;
+
+    typedef struct remixapi_Rect2D {
+      int32_t left;
+      int32_t top;
+      int32_t right;
+      int32_t bottom;
+    } remixapi_Rect2D;
+
+    typedef struct remixapi_Float2D {
+      float x;
+      float y;
+    } remixapi_Float2D;
+
+    typedef struct remixapi_Float3D {
+      float x;
+      float y;
+      float z;
+    } remixapi_Float3D;
+
+    typedef struct remixapi_Float4D {
+      float x;
+      float y;
+      float z;
+      float w;
+    } remixapi_Float4D;
+
+    typedef struct remixapi_Transform {
+      float matrix[3][4];
+    } remixapi_Transform;
+
+    //typedef struct remixapi_MaterialHandle_T* remixapi_MaterialHandle;
+    //typedef struct remixapi_MeshHandle_T* remixapi_MeshHandle;
+    //typedef struct remixapi_LightHandle_T* remixapi_LightHandle;
+
+    typedef const wchar_t* remixapi_Path;
+
+    typedef struct remixapi_MaterialInfoOpaqueEXT {
+      remixapi_StructType sType;
+      //void* pNext;
+      remixapi_Path       roughnessTexture;
+      remixapi_Path       metallicTexture;
+      float               anisotropy;
+      remixapi_Float3D    albedoConstant;
+      float               opacityConstant;
+      float               roughnessConstant;
+      float               metallicConstant;
+      remixapi_Bool       thinFilmThickness_hasvalue;
+      float               thinFilmThickness_value;
+      remixapi_Bool       alphaIsThinFilmThickness;
+      remixapi_Path       heightTexture;
+      float               heightTextureStrength;
+      // If true, InstanceInfoBlendEXT is used as a source for alpha state
+      remixapi_Bool       useDrawCallAlphaState;
+      remixapi_Bool       blendType_hasvalue;
+      int                 blendType_value;
+      remixapi_Bool       invertedBlend;
+      int                 alphaTestType;
+      uint8_t             alphaReferenceValue;
+    } remixapi_MaterialInfoOpaqueEXT;
+
+    // Valid only if remixapi_MaterialInfo contains remixapi_MaterialInfoOpaqueEXT in pNext chain
+    typedef struct remixapi_MaterialInfoOpaqueSubsurfaceEXT {
+      remixapi_StructType sType;
+      //void* pNext;
+      remixapi_Path       subsurfaceTransmittanceTexture;
+      remixapi_Path       subsurfaceThicknessTexture;
+      remixapi_Path       subsurfaceSingleScatteringAlbedoTexture;
+      remixapi_Float3D    subsurfaceTransmittanceColor;
+      float               subsurfaceMeasurementDistance;
+      remixapi_Float3D    subsurfaceSingleScatteringAlbedo;
+      float               subsurfaceVolumetricAnisotropy;
+    } remixapi_MaterialInfoOpaqueSubsurfaceEXT;
+
+    typedef struct remixapi_MaterialInfoTranslucentEXT {
+      remixapi_StructType sType;
+      //void* pNext;
+      remixapi_Path       transmittanceTexture;
+      float               refractiveIndex;
+      remixapi_Float3D    transmittanceColor;
+      float               transmittanceMeasurementDistance;
+      remixapi_Bool       thinWallThickness_hasvalue;
+      float               thinWallThickness_value;
+      remixapi_Bool       useDiffuseLayer;
+    } remixapi_MaterialInfoTranslucentEXT;
+
+    typedef struct remixapi_MaterialInfoPortalEXT {
+      remixapi_StructType sType;
+      //void* pNext;
+      uint8_t             rayPortalIndex;
+      float               rotationSpeed;
+    } remixapi_MaterialInfoPortalEXT;
+
+    typedef struct remixapi_MaterialInfo {
+      remixapi_StructType sType;
+      //void* pNext;
+      uint64_t            hash;
+      remixapi_Path       albedoTexture;
+      remixapi_Path       normalTexture;
+      remixapi_Path       tangentTexture;
+      remixapi_Path       emissiveTexture;
+      float               emissiveIntensity;
+      remixapi_Float3D    emissiveColorConstant;
+      uint8_t             spriteSheetRow;
+      uint8_t             spriteSheetCol;
+      uint8_t             spriteSheetFps;
+      uint8_t             filterMode; // Nearest: 0   Linear: 1
+      uint8_t             wrapModeU; // Clamp: 0   Repeat: 1   Mirrored_Repeat: 2   Clip: 3
+      uint8_t             wrapModeV; // Clamp: 0   Repeat: 1   Mirrored_Repeat: 2   Clip: 3
+    } remixapi_MaterialInfo;
+
+
+    typedef struct remixapi_HardcodedVertex {
+      float    position[3];
+      float    normal[3];
+      float    texcoord[2];
+      uint32_t color;
+      uint32_t _pad0;
+      uint32_t _pad1;
+      uint32_t _pad2;
+      uint32_t _pad3;
+      uint32_t _pad4;
+      uint32_t _pad5;
+      uint32_t _pad6;
+    } remixapi_HardcodedVertex;
+
+    // # TODO remixapi_MeshInfoSkinning
+
+    typedef struct remixapi_MeshInfoSurfaceTriangles {
+      const remixapi_HardcodedVertex* vertices_values;
+      uint64_t                        vertices_count;
+      const uint32_t*                 indices_values;
+      uint64_t                        indices_count;
+      remixapi_Bool                   skinning_hasvalue;
+      //remixapi_MeshInfoSkinning       skinning_value; // # TODO
+      uint64_t                        material; // CHANGED - was remixapi_MaterialHandle
+    } remixapi_MeshInfoSurfaceTriangles;
+
+    typedef struct remixapi_MeshInfo {
+      remixapi_StructType                      sType;
+      //void* pNext;
+      uint64_t                                 hash;
+      const remixapi_MeshInfoSurfaceTriangles* surfaces_values;
+      uint32_t                                 surfaces_count;
+    } remixapi_MeshInfo;
+
+
+    typedef struct remixapi_LightInfoLightShaping {
+      // The direction the Light Shaping is pointing in. Must be normalized.
+      remixapi_Float3D               direction;
+      float                          coneAngleDegrees;
+      float                          coneSoftness;
+      float                          focusExponent;
+    } remixapi_LightInfoLightShaping;
+
+    typedef struct remixapi_LightInfoSphereEXT {
+      remixapi_StructType            sType;
+      //void* pNext;
+      remixapi_Float3D               position;
+      float                          radius;
+      remixapi_Bool                  shaping_hasvalue;
+      remixapi_LightInfoLightShaping shaping_value;
+    } remixapi_LightInfoSphereEXT;
+
+    typedef struct remixapi_LightInfoRectEXT {
+      remixapi_StructType            sType;
+      //void* pNext;
+      remixapi_Float3D               position;
+      // The X axis of the Rect Light. Must be normalized and orthogonal to the Y and direction axes.
+      remixapi_Float3D               xAxis;
+      float                          xSize;
+      // The Y axis of the Rect Light. Must be normalized and orthogonal to the X and direction axes.
+      remixapi_Float3D               yAxis;
+      float                          ySize;
+      // The direction the Rect Light is pointing in, should match the Shaping direction if present.
+      // Must be normalized and orthogonal to the X and Y axes.
+      remixapi_Float3D               direction;
+      remixapi_Bool                  shaping_hasvalue;
+      remixapi_LightInfoLightShaping shaping_value;
+    } remixapi_LightInfoRectEXT;
+
+    typedef struct remixapi_LightInfoDiskEXT {
+      remixapi_StructType            sType;
+      //void* pNext;
+      remixapi_Float3D               position;
+      // The X axis of the Disk Light. Must be normalized and orthogonal to the Y and direction axes.
+      remixapi_Float3D               xAxis;
+      float                          xRadius;
+      // The Y axis of the Disk Light. Must be normalized and orthogonal to the X and direction axes.
+      remixapi_Float3D               yAxis;
+      float                          yRadius;
+      // The direction the Disk Light is pointing in, should match the Shaping direction if present
+      // Must be normalized and orthogonal to the X and Y axes.
+      remixapi_Float3D               direction;
+      remixapi_Bool                  shaping_hasvalue;
+      remixapi_LightInfoLightShaping shaping_value;
+    } remixapi_LightInfoDiskEXT;
+
+    typedef struct remixapi_LightInfoCylinderEXT {
+      remixapi_StructType            sType;
+      //void* pNext;
+      remixapi_Float3D               position;
+      float                          radius;
+      // The "center" axis of the Cylinder Light. Must be normalized.
+      remixapi_Float3D               axis;
+      float                          axisLength;
+    } remixapi_LightInfoCylinderEXT;
+
+    typedef struct remixapi_LightInfoDistantEXT {
+      remixapi_StructType             sType;
+      //void* pNext;
+      // The direction the Distant Light is pointing in. Must be normalized.
+      remixapi_Float3D                direction;
+      float                           angularDiameterDegrees;
+    } remixapi_LightInfoDistantEXT;
+
+    typedef struct remixapi_LightInfo {
+      remixapi_StructType             sType;
+      //void* pNext;
+      uint64_t                        hash;
+      remixapi_Float3D                radiance;
+    } remixapi_LightInfo;
+  }
+
+  // --------------------------------------------
+  // remix api types end ->
+
+  typedef void(BRIDGEAPI_PTR* PFN_bridgeapi_DebugPrint)(const char* text);
+  typedef uint64_t(BRIDGEAPI_PTR* PFN_bridgeapi_CreateOpaqueMaterial)(const x86::remixapi_MaterialInfo* info, const x86::remixapi_MaterialInfoOpaqueEXT* ext, const x86::remixapi_MaterialInfoOpaqueSubsurfaceEXT* ext_ss);
+  typedef uint64_t(BRIDGEAPI_PTR* PFN_bridgeapi_CreateTranslucentMaterial)(const x86::remixapi_MaterialInfo* info, const x86::remixapi_MaterialInfoTranslucentEXT* ext);
+  typedef uint64_t(BRIDGEAPI_PTR* PFN_bridgeapi_CreatePortalMaterial)(const x86::remixapi_MaterialInfo* info, const x86::remixapi_MaterialInfoPortalEXT* ext);
+  typedef void(BRIDGEAPI_PTR* PFN_bridgeapi_DestroyMaterial)(uint64_t handle);
+  typedef uint64_t(BRIDGEAPI_PTR* PFN_bridgeapi_CreateTriangleMesh)(const x86::remixapi_MeshInfo* info);
+  typedef void(BRIDGEAPI_PTR* PFN_bridgeapi_DestroyMesh)(uint64_t handle);
+  typedef void(BRIDGEAPI_PTR* PFN_bridgeapi_DrawMeshInstance)(uint64_t handle, const x86::remixapi_Transform* t, x86::remixapi_Bool double_sided);
+  typedef uint64_t(BRIDGEAPI_PTR* PFN_bridgeapi_CreateSphereLight)(const x86::remixapi_LightInfo* info, const x86::remixapi_LightInfoSphereEXT* ext);
+  typedef uint64_t(BRIDGEAPI_PTR* PFN_bridgeapi_CreateRectLight)(const x86::remixapi_LightInfo* info, const x86::remixapi_LightInfoRectEXT* ext);
+  typedef uint64_t(BRIDGEAPI_PTR* PFN_bridgeapi_CreateDiskLight)(const x86::remixapi_LightInfo* info, const x86::remixapi_LightInfoDiskEXT* ext);
+  typedef uint64_t(BRIDGEAPI_PTR* PFN_bridgeapi_CreateCylinderLight)(const x86::remixapi_LightInfo* info, const x86::remixapi_LightInfoCylinderEXT* ext);
+  typedef uint64_t(BRIDGEAPI_PTR* PFN_bridgeapi_CreateDistantLight)(const x86::remixapi_LightInfo* info, const x86::remixapi_LightInfoDistantEXT* ext);
+  typedef void(BRIDGEAPI_PTR* PFN_bridgeapi_DestroyLight)(uint64_t handle);
+  typedef void(BRIDGEAPI_PTR* PFN_bridgeapi_DrawLightInstance)(uint64_t handle);
+  typedef void(BRIDGEAPI_PTR* PFN_bridgeapi_SetConfigVariable)(const char* var, const char* value);
+  typedef void(BRIDGEAPI_PTR* PFN_bridgeapi_RegisterDevice)(void);
+  typedef void(__cdecl* PFN_bridgeapi_RegisterEndSceneCallback)(void);
+
+  typedef struct bridgeapi_Interface {
+    bool initialized;
+    PFN_bridgeapi_DebugPrint                DebugPrint;                // const char* text
+    PFN_bridgeapi_CreateOpaqueMaterial      CreateOpaqueMaterial;      // x86::remixapi_MaterialInfo*
+    PFN_bridgeapi_CreateTranslucentMaterial CreateTranslucentMaterial; // x86::remixapi_MaterialInfo* --- x86::remixapi_MaterialInfoTranslucentEXT*
+    PFN_bridgeapi_CreatePortalMaterial      CreatePortalMaterial;      // x86::remixapi_MaterialInfo* --- x86::remixapi_MaterialInfoPortalEXT*
+    PFN_bridgeapi_DestroyMaterial           DestroyMaterial;           // uint64_t handle
+    PFN_bridgeapi_CreateTriangleMesh        CreateTriangleMesh;        // x86::remixapi_MeshInfo*
+    PFN_bridgeapi_DestroyMesh               DestroyMesh;               // uint64_t handle
+    PFN_bridgeapi_DrawMeshInstance          DrawMeshInstance;          // uint64_t handle --- x86::remixapi_Transform* t --- x86::remixapi_Bool double_sided
+    PFN_bridgeapi_CreateSphereLight         CreateSphereLight;         // x86::remixapi_LightInfo* --- x86::remixapi_LightInfoSphereEXT*
+    PFN_bridgeapi_CreateRectLight           CreateRectLight;           // x86::remixapi_LightInfo* --- x86::remixapi_LightInfoRectEXT*
+    PFN_bridgeapi_CreateDiskLight           CreateDiskLight;           // x86::remixapi_LightInfo* --- x86::remixapi_LightInfoDiskEXT*
+    PFN_bridgeapi_CreateCylinderLight       CreateCylinderLight;       // x86::remixapi_LightInfo* --- x86::remixapi_LightInfoCylinderEXT*
+    PFN_bridgeapi_CreateDistantLight        CreateDistantLight;        // x86::remixapi_LightInfo* --- x86::remixapi_LightInfoDistantEXT*
+    PFN_bridgeapi_DestroyLight              DestroyLight;              // uint64_t handle
+    PFN_bridgeapi_DrawLightInstance         DrawLightInstance;         // uint64_t handle
+    PFN_bridgeapi_SetConfigVariable         SetConfigVariable;         // const char* var --- const char* value
+    PFN_bridgeapi_RegisterDevice            RegisterDevice;            // void
+    void                                  (*RegisterEndSceneCallback)(PFN_bridgeapi_RegisterEndSceneCallback callback);
+  } bridgeapi_Interface;
+
+  BRIDGE_API BRIDGEAPI_ErrorCode __cdecl bridgeapi_InitFuncs(bridgeapi_Interface* out_result);
+  typedef BRIDGEAPI_ErrorCode(__cdecl* PFN_bridgeapi_InitFuncs)(bridgeapi_Interface* out_result);
+
+  // --------
+  // --------
+
+  inline BRIDGEAPI_ErrorCode bridgeapi_initialize(bridgeapi_Interface* out_bridgeInterface) {
+
+    PFN_bridgeapi_InitFuncs pfn_Initialize = nullptr;
+  	HMODULE hModule = GetModuleHandleA("d3d9.dll");
+    if (hModule) {
+      PROC func = GetProcAddress(hModule, "bridgeapi_InitFuncs");
+      if (func) {
+      	pfn_Initialize = (PFN_bridgeapi_InitFuncs) func;
+      }
+      else {
+      	return BRIDGEAPI_ERROR_CODE_GET_PROC_ADDRESS_FAILURE;
+      }
+    
+      bridgeapi_Interface bridgeInterface = { 0 };
+      bridgeapi_ErrorCode status = pfn_Initialize(&bridgeInterface);
+      if (status != BRIDGEAPI_ERROR_CODE_SUCCESS) {
+      	return status;
+      }
+    
+      bridgeInterface.initialized = true;
+      *out_bridgeInterface = bridgeInterface;
+    
+      return status;
+    }
+  	return BRIDGEAPI_ERROR_CODE_GET_MODULE_HANDLE_FAILURE;
+  }
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // BRIDGE_C_H_

--- a/src/api/remix_api/remix_c.h
+++ b/src/api/remix_api/remix_c.h
@@ -1,0 +1,829 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef REMIX_C_H_
+#define REMIX_C_H_
+
+#include <stdint.h>
+#include <windows.h>
+
+#if _WIN64 != 1
+  #error Remix API requires 64-bit for the ray tracing features.
+#endif
+
+
+// __stdcall convention
+#define REMIXAPI_CALL __stdcall
+#define REMIXAPI_PTR  REMIXAPI_CALL
+
+#ifdef REMIX_LIBRARY_EXPORTS
+  #define REMIXAPI __declspec(dllexport)
+#else
+  #define REMIXAPI __declspec(dllimport)
+#endif // REMIX_LIBRARY_EXPORTS
+
+
+#define REMIXAPI_VERSION_MAKE(major, minor, patch) ( \
+    (((uint64_t)(major)) << 48) | \
+    (((uint64_t)(minor)) << 16) | \
+    (((uint64_t)(patch))      ) )
+#define REMIXAPI_VERSION_GET_MAJOR(version) (((uint64_t)(version) >> 48) & (uint64_t)0xFFFF)
+#define REMIXAPI_VERSION_GET_MINOR(version) (((uint64_t)(version) >> 16) & (uint64_t)0xFFFFFFFF)
+#define REMIXAPI_VERSION_GET_PATCH(version) (((uint64_t)(version)      ) & (uint64_t)0xFFFF)
+
+#define REMIXAPI_VERSION_MAJOR 0
+#define REMIXAPI_VERSION_MINOR 4
+#define REMIXAPI_VERSION_PATCH 1
+
+
+// External
+typedef struct IDirect3D9Ex       IDirect3D9Ex;
+typedef struct IDirect3DDevice9Ex IDirect3DDevice9Ex;
+typedef struct IDirect3DSurface9  IDirect3DSurface9;
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+  typedef enum remixapi_StructType {
+    REMIXAPI_STRUCT_TYPE_NONE                                 = 0,
+    REMIXAPI_STRUCT_TYPE_INITIALIZE_LIBRARY_INFO              = 1,
+    REMIXAPI_STRUCT_TYPE_MATERIAL_INFO                        = 2,
+    REMIXAPI_STRUCT_TYPE_MATERIAL_INFO_PORTAL_EXT             = 3,
+    REMIXAPI_STRUCT_TYPE_MATERIAL_INFO_TRANSLUCENT_EXT        = 4,
+    REMIXAPI_STRUCT_TYPE_MATERIAL_INFO_OPAQUE_EXT             = 5,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO                           = 6,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_DISTANT_EXT               = 7,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_CYLINDER_EXT              = 8,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_DISK_EXT                  = 9,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_RECT_EXT                  = 10,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_SPHERE_EXT                = 11,
+    REMIXAPI_STRUCT_TYPE_MESH_INFO                            = 12,
+    REMIXAPI_STRUCT_TYPE_INSTANCE_INFO                        = 13,
+    REMIXAPI_STRUCT_TYPE_INSTANCE_INFO_BONE_TRANSFORMS_EXT    = 14,
+    REMIXAPI_STRUCT_TYPE_INSTANCE_INFO_BLEND_EXT              = 15,
+    REMIXAPI_STRUCT_TYPE_CAMERA_INFO                          = 16,
+    REMIXAPI_STRUCT_TYPE_CAMERA_INFO_PARAMETERIZED_EXT        = 17,
+    REMIXAPI_STRUCT_TYPE_MATERIAL_INFO_OPAQUE_SUBSURFACE_EXT  = 18,
+    REMIXAPI_STRUCT_TYPE_INSTANCE_INFO_OBJECT_PICKING_EXT     = 19,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_DOME_EXT                  = 20,
+    REMIXAPI_STRUCT_TYPE_LIGHT_INFO_USD_EXT                   = 21,
+    REMIXAPI_STRUCT_TYPE_STARTUP_INFO                         = 22,
+    REMIXAPI_STRUCT_TYPE_PRESENT_INFO                         = 23,
+    // NOTE: if adding a new struct, register it in 'rtx_remix_specialization.inl'
+  } remixapi_StructType;
+
+  typedef enum remixapi_ErrorCode {
+    REMIXAPI_ERROR_CODE_SUCCESS                           = 0,
+    REMIXAPI_ERROR_CODE_GENERAL_FAILURE                   = 1,
+    // WinAPI's LoadLibrary has failed
+    REMIXAPI_ERROR_CODE_LOAD_LIBRARY_FAILURE              = 2,
+    REMIXAPI_ERROR_CODE_INVALID_ARGUMENTS                 = 3,
+    // Couldn't find 'remixInitialize' function in the .dll
+    REMIXAPI_ERROR_CODE_GET_PROC_ADDRESS_FAILURE          = 4,
+    // CreateD3D9 / RegisterD3D9Device can be called only once
+    REMIXAPI_ERROR_CODE_ALREADY_EXISTS                    = 5,
+    // RegisterD3D9Device requires the device that was created with IDirect3DDevice9Ex, returned by CreateD3D9
+    REMIXAPI_ERROR_CODE_REGISTERING_NON_REMIX_D3D9_DEVICE = 6,
+    // RegisterD3D9Device was not called
+    REMIXAPI_ERROR_CODE_REMIX_DEVICE_WAS_NOT_REGISTERED   = 7,
+    REMIXAPI_ERROR_CODE_INCOMPATIBLE_VERSION              = 8,
+    // WinAPI's SetDllDirectory has failed
+    REMIXAPI_ERROR_CODE_SET_DLL_DIRECTORY_FAILURE         = 9,
+    // WinAPI's GetFullPathName has failed
+    REMIXAPI_ERROR_CODE_GET_FULL_PATH_NAME_FAILURE        = 10,
+    REMIXAPI_ERROR_CODE_NOT_INITIALIZED                   = 11,
+    // Error codes that are encoded as HRESULT, i.e. returned from D3D9 functions.
+    // Look MAKE_D3DHRESULT, but with _FACD3D=0x896, instead of D3D9's 0x876
+    REMIXAPI_ERROR_CODE_HRESULT_NO_REQUIRED_GPU_FEATURES      = 0x88960001,
+    REMIXAPI_ERROR_CODE_HRESULT_DRIVER_VERSION_BELOW_MINIMUM  = 0x88960002,
+    REMIXAPI_ERROR_CODE_HRESULT_DXVK_INSTANCE_EXTENSION_FAIL  = 0x88960003,
+    REMIXAPI_ERROR_CODE_HRESULT_VK_CREATE_INSTANCE_FAIL       = 0x88960004,
+    REMIXAPI_ERROR_CODE_HRESULT_VK_CREATE_DEVICE_FAIL         = 0x88960005,
+    REMIXAPI_ERROR_CODE_HRESULT_GRAPHICS_QUEUE_FAMILY_MISSING = 0x88960006,
+  } remixapi_ErrorCode;
+
+  typedef uint32_t remixapi_Bool;
+
+  typedef struct remixapi_Rect2D {
+    int32_t left;
+    int32_t top;
+    int32_t right;
+    int32_t bottom;
+  } remixapi_Rect2D;
+
+  typedef struct remixapi_Float2D {
+    float x;
+    float y;
+  } remixapi_Float2D;
+
+  typedef struct remixapi_Float3D {
+    float x;
+    float y;
+    float z;
+  } remixapi_Float3D;
+
+  typedef struct remixapi_Float4D {
+    float x;
+    float y;
+    float z;
+    float w;
+  } remixapi_Float4D;
+
+  typedef struct remixapi_Transform {
+    float matrix[3][4];
+  } remixapi_Transform;
+
+  typedef struct remixapi_MaterialHandle_T* remixapi_MaterialHandle;
+  typedef struct remixapi_MeshHandle_T* remixapi_MeshHandle;
+  typedef struct remixapi_LightHandle_T* remixapi_LightHandle;
+
+  typedef const wchar_t* remixapi_Path;
+
+
+
+  typedef struct remixapi_StartupInfo {
+    remixapi_StructType sType;
+    void*               pNext;
+    HWND                hwnd;
+    remixapi_Bool       disableSrgbConversionForOutput;
+    // If true, 'dxvk_GetExternalSwapchain' can be used to retrieve a raw VkImage,
+    // so the application can present it, for example by using OpenGL interop:
+    // converting VkImage to OpenGL, and presenting it via OpenGL.
+    // Default: false. Use VkSwapchainKHR to present frame into HWND.
+    remixapi_Bool       forceNoVkSwapchain;
+    remixapi_Bool       editorModeEnabled;
+  } remixapi_StartupInfo;
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_Startup)(const remixapi_StartupInfo* info);
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_Shutdown)(void);
+
+
+
+  typedef struct remixapi_MaterialInfoOpaqueEXT {
+    remixapi_StructType sType;
+    void*               pNext;
+    remixapi_Path       roughnessTexture;
+    remixapi_Path       metallicTexture;
+    float               anisotropy;
+    remixapi_Float3D    albedoConstant;
+    float               opacityConstant;
+    float               roughnessConstant;
+    float               metallicConstant;
+    remixapi_Bool       thinFilmThickness_hasvalue;
+    float               thinFilmThickness_value;
+    remixapi_Bool       alphaIsThinFilmThickness;
+    remixapi_Path       heightTexture;
+    float               heightTextureStrength;
+    // If true, InstanceInfoBlendEXT is used as a source for alpha state
+    remixapi_Bool       useDrawCallAlphaState;
+    remixapi_Bool       blendType_hasvalue;
+    int                 blendType_value;
+    remixapi_Bool       invertedBlend;
+    int                 alphaTestType;
+    uint8_t             alphaReferenceValue;
+  } remixapi_MaterialInfoOpaqueEXT;
+
+  // Valid only if remixapi_MaterialInfo contains remixapi_MaterialInfoOpaqueEXT in pNext chain
+  typedef struct remixapi_MaterialInfoOpaqueSubsurfaceEXT {
+    remixapi_StructType sType;
+    void*               pNext;
+    remixapi_Path       subsurfaceTransmittanceTexture;
+    remixapi_Path       subsurfaceThicknessTexture;
+    remixapi_Path       subsurfaceSingleScatteringAlbedoTexture;
+    remixapi_Float3D    subsurfaceTransmittanceColor;
+    float               subsurfaceMeasurementDistance;
+    remixapi_Float3D    subsurfaceSingleScatteringAlbedo;
+    float               subsurfaceVolumetricAnisotropy;
+  } remixapi_MaterialInfoOpaqueSubsurfaceEXT;
+
+  typedef struct remixapi_MaterialInfoTranslucentEXT {
+    remixapi_StructType sType;
+    void*               pNext;
+    remixapi_Path       transmittanceTexture;
+    float               refractiveIndex;
+    remixapi_Float3D    transmittanceColor;
+    float               transmittanceMeasurementDistance;
+    remixapi_Bool       thinWallThickness_hasvalue;
+    float               thinWallThickness_value;
+    remixapi_Bool       useDiffuseLayer;
+  } remixapi_MaterialInfoTranslucentEXT;
+
+  typedef struct remixapi_MaterialInfoPortalEXT {
+    remixapi_StructType sType;
+    void*               pNext;
+    uint8_t             rayPortalIndex;
+    float               rotationSpeed;
+  } remixapi_MaterialInfoPortalEXT;
+
+  typedef struct remixapi_MaterialInfo {
+    remixapi_StructType sType;
+    void*               pNext;
+    uint64_t            hash;
+    remixapi_Path       albedoTexture;
+    remixapi_Path       normalTexture;
+    remixapi_Path       tangentTexture;
+    remixapi_Path       emissiveTexture;
+    float               emissiveIntensity;
+    remixapi_Float3D    emissiveColorConstant;
+    uint8_t             spriteSheetRow;
+    uint8_t             spriteSheetCol;
+    uint8_t             spriteSheetFps;
+    uint8_t             filterMode;
+    uint8_t             wrapModeU;
+    uint8_t             wrapModeV;
+  } remixapi_MaterialInfo;
+
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_CreateMaterial)(
+    const remixapi_MaterialInfo*  info,
+    remixapi_MaterialHandle*      out_handle);
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_DestroyMaterial)(
+    remixapi_MaterialHandle       handle);
+
+  typedef struct remixapi_HardcodedVertex {
+    float    position[3];
+    float    normal[3];
+    float    texcoord[2];
+    uint32_t color;
+    uint32_t _pad0;
+    uint32_t _pad1;
+    uint32_t _pad2;
+    uint32_t _pad3;
+    uint32_t _pad4;
+    uint32_t _pad5;
+    uint32_t _pad6;
+  } remixapi_HardcodedVertex;
+
+  typedef struct remixapi_MeshInfoSkinning {
+    uint32_t                        bonesPerVertex;
+    // Each tuple of 'bonesPerVertex' float-s defines a vertex.
+    // I.e. the size must be (bonesPerVertex * vertexCount).
+    const float*                    blendWeights_values;
+    uint32_t                        blendWeights_count;
+    // Each tuple of 'bonesPerVertex' uint32_t-s defines a vertex.
+    // I.e. the size must be (bonesPerVertex * vertexCount).
+    const uint32_t*                 blendIndices_values;
+    uint32_t                        blendIndices_count;
+  } remixapi_MeshInfoSkinning;
+
+  typedef struct remixapi_MeshInfoSurfaceTriangles {
+    const remixapi_HardcodedVertex* vertices_values;
+    uint64_t                        vertices_count;
+    const uint32_t*                 indices_values;
+    uint64_t                        indices_count;
+    remixapi_Bool                   skinning_hasvalue;
+    remixapi_MeshInfoSkinning       skinning_value;
+    remixapi_MaterialHandle         material;
+  } remixapi_MeshInfoSurfaceTriangles;
+
+  typedef struct remixapi_MeshInfo {
+    remixapi_StructType                      sType;
+    void*                                    pNext;
+    uint64_t                                 hash;
+    const remixapi_MeshInfoSurfaceTriangles* surfaces_values;
+    uint32_t                                 surfaces_count;
+  } remixapi_MeshInfo;
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_CreateMesh)(
+    const remixapi_MeshInfo*  info,
+    remixapi_MeshHandle*      out_handle);
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_DestroyMesh)(
+    remixapi_MeshHandle       handle);
+
+
+
+  typedef enum remixapi_CameraType {
+    REMIXAPI_CAMERA_TYPE_WORLD,
+    REMIXAPI_CAMERA_TYPE_SKY,
+    REMIXAPI_CAMERA_TYPE_VIEW_MODEL,
+  } remixapi_CameraType;
+
+  typedef struct remixapi_CameraInfoParameterizedEXT {
+    remixapi_StructType sType;
+    void*               pNext;
+    remixapi_Float3D    position;
+    remixapi_Float3D    forward;
+    remixapi_Float3D    up;
+    remixapi_Float3D    right;
+    float               fovYInDegrees;
+    float               aspect;
+    float               nearPlane;
+    float               farPlane;
+  } remixapi_CameraInfoParameterizedEXT;
+
+  typedef struct remixapi_CameraInfo {
+    remixapi_StructType sType;
+    void*               pNext;
+    remixapi_CameraType type;
+    float               view[4][4];
+    float               projection[4][4];
+  } remixapi_CameraInfo;
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_SetupCamera)(
+    const remixapi_CameraInfo* info);
+
+
+
+#define REMIXAPI_INSTANCE_INFO_MAX_BONES_COUNT 256
+
+  typedef struct remixapi_InstanceInfoBoneTransformsEXT {
+      remixapi_StructType       sType;
+      void*                     pNext;
+      const remixapi_Transform* boneTransforms_values;
+      uint32_t                  boneTransforms_count;
+  } remixapi_InstanceInfoBoneTransformsEXT;
+
+  typedef struct remixapi_InstanceInfoBlendEXT {
+    remixapi_StructType sType;
+    void*               pNext;
+    remixapi_Bool       alphaTestEnabled;
+    uint8_t             alphaTestReferenceValue;
+    uint32_t            alphaTestCompareOp;
+    remixapi_Bool       alphaBlendEnabled;
+    uint32_t            srcColorBlendFactor;
+    uint32_t            dstColorBlendFactor;
+    uint32_t            colorBlendOp;
+    uint32_t            textureColorArg1Source;
+    uint32_t            textureColorArg2Source;
+    uint32_t            textureColorOperation;
+    uint32_t            textureAlphaArg1Source;
+    uint32_t            textureAlphaArg2Source;
+    uint32_t            textureAlphaOperation;
+    uint32_t            tFactor;
+    remixapi_Bool       isTextureFactorBlend;
+  } remixapi_InstanceInfoBlendEXT;
+
+  typedef struct remixapi_InstanceInfoObjectPickingEXT {
+    remixapi_StructType            sType;
+    void*                          pNext;
+    // A value to write for 'RequestObjectPicking'
+    uint32_t                       objectPickingValue;
+  } remixapi_InstanceInfoObjectPickingEXT;
+
+  typedef enum remixapi_InstanceCategoryBit {
+    REMIXAPI_INSTANCE_CATEGORY_BIT_WORLD_UI                  = 1 << 0,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_WORLD_MATTE               = 1 << 1,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_SKY                       = 1 << 2,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE                    = 1 << 3,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_LIGHTS             = 1 << 4,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_ANTI_CULLING       = 1 << 5,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_MOTION_BLUR        = 1 << 6,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_OPACITY_MICROMAP   = 1 << 7,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_HIDDEN                    = 1 << 8,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_PARTICLE                  = 1 << 9,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_BEAM                      = 1 << 10,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_STATIC              = 1 << 11,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_DYNAMIC             = 1 << 12,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_SINGLE_OFFSET       = 1 << 13,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_DECAL_NO_OFFSET           = 1 << 14,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_ALPHA_BLEND_TO_CUTOUT     = 1 << 15,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_TERRAIN                   = 1 << 16,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_ANIMATED_WATER            = 1 << 17,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_THIRD_PERSON_PLAYER_MODEL = 1 << 18,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_THIRD_PERSON_PLAYER_BODY  = 1 << 19,
+    REMIXAPI_INSTANCE_CATEGORY_BIT_IGNORE_BAKED_LIGHTING     = 1 << 20,
+  } remixapi_InstanceCategoryBit;
+
+  typedef uint32_t remixapi_InstanceCategoryFlags;
+
+  typedef struct remixapi_InstanceInfo {
+    remixapi_StructType            sType;
+    void*                          pNext;
+    remixapi_InstanceCategoryFlags categoryFlags;
+    remixapi_MeshHandle            mesh;
+    remixapi_Transform             transform;
+    remixapi_Bool                  doubleSided;
+  } remixapi_InstanceInfo;
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_DrawInstance)(
+    const remixapi_InstanceInfo* info);
+
+
+
+  typedef struct remixapi_LightInfoLightShaping {
+    // The direction the Light Shaping is pointing in. Must be normalized.
+    remixapi_Float3D               direction;
+    float                          coneAngleDegrees;
+    float                          coneSoftness;
+    float                          focusExponent;
+  } remixapi_LightInfoLightShaping;
+
+  typedef struct remixapi_LightInfoSphereEXT {
+    remixapi_StructType            sType;
+    void*                          pNext;
+    remixapi_Float3D               position;
+    float                          radius;
+    remixapi_Bool                  shaping_hasvalue;
+    remixapi_LightInfoLightShaping shaping_value;
+  } remixapi_LightInfoSphereEXT;
+
+  typedef struct remixapi_LightInfoRectEXT {
+    remixapi_StructType            sType;
+    void*                          pNext;
+    remixapi_Float3D               position;
+    // The X axis of the Rect Light. Must be normalized and orthogonal to the Y and direction axes.
+    remixapi_Float3D               xAxis;
+    float                          xSize;
+    // The Y axis of the Rect Light. Must be normalized and orthogonal to the X and direction axes.
+    remixapi_Float3D               yAxis;
+    float                          ySize;
+    // The direction the Rect Light is pointing in, should match the Shaping direction if present.
+    // Must be normalized and orthogonal to the X and Y axes.
+    remixapi_Float3D               direction;
+    remixapi_Bool                  shaping_hasvalue;
+    remixapi_LightInfoLightShaping shaping_value;
+  } remixapi_LightInfoRectEXT;
+
+  typedef struct remixapi_LightInfoDiskEXT {
+    remixapi_StructType            sType;
+    void*                          pNext;
+    remixapi_Float3D               position;
+    // The X axis of the Disk Light. Must be normalized and orthogonal to the Y and direction axes.
+    remixapi_Float3D               xAxis;
+    float                          xRadius;
+    // The Y axis of the Disk Light. Must be normalized and orthogonal to the X and direction axes.
+    remixapi_Float3D               yAxis;
+    float                          yRadius;
+    // The direction the Disk Light is pointing in, should match the Shaping direction if present
+    // Must be normalized and orthogonal to the X and Y axes.
+    remixapi_Float3D               direction;
+    remixapi_Bool                  shaping_hasvalue;
+    remixapi_LightInfoLightShaping shaping_value;
+  } remixapi_LightInfoDiskEXT;
+
+  typedef struct remixapi_LightInfoCylinderEXT {
+    remixapi_StructType            sType;
+    void*                          pNext;
+    remixapi_Float3D               position;
+    float                          radius;
+    // The "center" axis of the Cylinder Light. Must be normalized.
+    remixapi_Float3D               axis;
+    float                          axisLength;
+  } remixapi_LightInfoCylinderEXT;
+
+  typedef struct remixapi_LightInfoDistantEXT {
+    remixapi_StructType             sType;
+    void*                           pNext;
+    // The direction the Distant Light is pointing in. Must be normalized.
+    remixapi_Float3D                direction;
+    float                           angularDiameterDegrees;
+  } remixapi_LightInfoDistantEXT;
+
+  typedef struct remixapi_LightInfoDomeEXT {
+    remixapi_StructType             sType;
+    void*                           pNext;
+    remixapi_Transform              transform;
+    remixapi_Path                   colorTexture;
+  } remixapi_LightInfoDomeEXT;
+
+  // Attachable to remixapi_LightInfo.
+  // If attached, 'remixapi_LightInfo::radiance' is ignored.
+  // Any other attached 'remixapi_LightInfo*EXT' are ignored.
+  // Most fields correspond to a usd token. Set to null, if no value.
+  typedef struct remixapi_LightInfoUSDEXT {
+    remixapi_StructType             sType;
+    void*                           pNext;
+    remixapi_StructType             lightType;
+    remixapi_Transform              transform;
+    const float*                    pRadius;            // "radius"
+    const float*                    pWidth;             // "width"
+    const float*                    pHeight;            // "height"
+    const float*                    pLength;            // "length"
+    const float*                    pAngleRadians;      // "angle"
+    const remixapi_Bool*            pEnableColorTemp;   // "enableColorTemperature"
+    const remixapi_Float3D*         pColor;             // "color"
+    const float*                    pColorTemp;         // "colorTemperature"
+    const float*                    pExposure;          // "exposure"
+    const float*                    pIntensity;         // "intensity"
+    const float*                    pConeAngleRadians;  // "shaping:cone:angle"
+    const float*                    pConeSoftness;      // "shaping:cone:softness"
+    const float*                    pFocus;             // "shaping:focus"
+  } remixapi_LightInfoUSDEXT;
+
+  typedef struct remixapi_LightInfo {
+    remixapi_StructType             sType;
+    void*                           pNext;
+    uint64_t                        hash;
+    remixapi_Float3D                radiance;
+  } remixapi_LightInfo;
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_CreateLight)(
+    const remixapi_LightInfo* info,
+    remixapi_LightHandle*     out_handle);
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_DestroyLight)(
+    remixapi_LightHandle      handle);
+
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_DrawLightInstance)(
+    remixapi_LightHandle      lightHandle);
+
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_SetConfigVariable)(
+    const char*               key,
+    const char*               value);
+
+  typedef struct remixapi_PresentInfo {
+    remixapi_StructType       sType;
+    void*                     pNext;
+    HWND                      hwndOverride; // Can be NULL
+  } remixapi_PresentInfo;
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_Present)(const remixapi_PresentInfo* info);
+
+  typedef void (REMIXAPI_PTR* PFN_remixapi_pick_RequestObjectPickingUserCallback)(
+    const uint32_t*           objectPickingValues_values,
+    uint32_t                  objectPickingValues_count,
+    void*                     callbackUserData);
+
+  // Invokes 'callback' on a successful readback of 'remixapi_InstanceInfoObjectPickingEXT::objectPickingValue'
+  // of objects that are drawn in the 'pixelRegion'. 'pixelRegion' specified relative to the output size,
+  // not render size. 'callback' can be invoked from any thread.
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_pick_RequestObjectPicking)(
+    const remixapi_Rect2D*                              pixelRegion,
+    PFN_remixapi_pick_RequestObjectPickingUserCallback  callback,
+    void*                                               callbackUserData);
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_pick_HighlightObjects)(
+    const uint32_t*           objectPickingValues_values,
+    uint32_t                  objectPickingValues_count,
+    uint8_t                   colorR,
+    uint8_t                   colorG,
+    uint8_t                   colorB);
+
+
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_dxvk_CreateD3D9)(
+    remixapi_Bool       editorModeEnabled,
+    IDirect3D9Ex**      out_pD3D9);
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_dxvk_RegisterD3D9Device)(
+    IDirect3DDevice9Ex* d3d9Device);
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_dxvk_GetExternalSwapchain)(
+    uint64_t*           out_vkImage,
+    uint64_t*           out_vkSemaphoreRenderingDone,
+    uint64_t*           out_vkSemaphoreResumeSemaphore);
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_dxvk_GetVkImage)(
+    IDirect3DSurface9*  source,
+    uint64_t*           out_vkImage);
+
+  typedef enum remixapi_dxvk_CopyRenderingOutputType {
+    REMIXAPI_DXVK_COPY_RENDERING_OUTPUT_TYPE_FINAL_COLOR = 0,
+    REMIXAPI_DXVK_COPY_RENDERING_OUTPUT_TYPE_DEPTH = 1,
+    REMIXAPI_DXVK_COPY_RENDERING_OUTPUT_TYPE_NORMALS = 2,
+    REMIXAPI_DXVK_COPY_RENDERING_OUTPUT_TYPE_OBJECT_PICKING = 3,
+  } remixapi_dxvk_CopyRenderingOutputType;
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_dxvk_CopyRenderingOutput)(
+    IDirect3DSurface9*                    destination,
+    remixapi_dxvk_CopyRenderingOutputType type);
+
+  typedef remixapi_ErrorCode(REMIXAPI_PTR* PFN_remixapi_dxvk_SetDefaultOutput)(
+    remixapi_dxvk_CopyRenderingOutputType type,
+    const remixapi_Float4D* color);
+
+
+  typedef struct remixapi_InitializeLibraryInfo {
+    remixapi_StructType sType;
+    void*               pNext;
+    uint64_t            version;
+  } remixapi_InitializeLibraryInfo;
+
+  typedef struct remixapi_Interface {
+    PFN_remixapi_Shutdown           Shutdown;
+    PFN_remixapi_CreateMaterial     CreateMaterial;
+    PFN_remixapi_DestroyMaterial    DestroyMaterial;
+    PFN_remixapi_CreateMesh         CreateMesh;
+    PFN_remixapi_DestroyMesh        DestroyMesh;
+    PFN_remixapi_SetupCamera        SetupCamera;
+    PFN_remixapi_DrawInstance       DrawInstance;
+    PFN_remixapi_CreateLight        CreateLight;
+    PFN_remixapi_DestroyLight       DestroyLight;
+    PFN_remixapi_DrawLightInstance  DrawLightInstance;
+    PFN_remixapi_SetConfigVariable  SetConfigVariable;
+
+    // DXVK interoperability
+    PFN_remixapi_dxvk_CreateD3D9            dxvk_CreateD3D9;
+    PFN_remixapi_dxvk_RegisterD3D9Device    dxvk_RegisterD3D9Device;
+    PFN_remixapi_dxvk_GetExternalSwapchain  dxvk_GetExternalSwapchain;
+    PFN_remixapi_dxvk_GetVkImage            dxvk_GetVkImage;
+    PFN_remixapi_dxvk_CopyRenderingOutput   dxvk_CopyRenderingOutput;
+    PFN_remixapi_dxvk_SetDefaultOutput      dxvk_SetDefaultOutput;
+    // Object picking utils
+    PFN_remixapi_pick_RequestObjectPicking  pick_RequestObjectPicking;
+    PFN_remixapi_pick_HighlightObjects      pick_HighlightObjects;
+
+    PFN_remixapi_Startup            Startup;
+    PFN_remixapi_Present            Present;
+  } remixapi_Interface;
+
+  REMIXAPI remixapi_ErrorCode REMIXAPI_CALL remixapi_InitializeLibrary(
+    const remixapi_InitializeLibraryInfo* info,
+    remixapi_Interface*                   out_result);
+
+  typedef remixapi_ErrorCode(REMIXAPI_CALL* PFN_remixapi_InitializeLibrary)(
+    const remixapi_InitializeLibraryInfo* info,
+    remixapi_Interface*                   out_result);
+
+
+  inline remixapi_ErrorCode REMIXAPI_CALL remixapi_lib_loadRemixDllAndInitialize(
+    const wchar_t*      remixD3D9DllPath,
+    remixapi_Interface* out_remixInterface,
+    HMODULE*            out_remixDll
+  ) {
+    if (remixD3D9DllPath == NULL || remixD3D9DllPath[0] == '\0') {
+      return REMIXAPI_ERROR_CODE_INVALID_ARGUMENTS;
+    }
+    if (out_remixInterface == NULL || out_remixDll == NULL) {
+      return REMIXAPI_ERROR_CODE_INVALID_ARGUMENTS;
+    }
+
+    HMODULE remixDll = NULL;
+    PFN_remixapi_InitializeLibrary pfn_InitializeLibrary = NULL;
+    {
+      // firstly, try the default method first, e.g. DLL is already loaded, 
+      // DLL-s are around .exe, or an app has called SetDllDirectory
+      {
+        HMODULE dll = LoadLibraryW(remixD3D9DllPath);
+        if (dll) {
+          PROC func = GetProcAddress(dll, "remixapi_InitializeLibrary");
+          if (func) {
+            remixDll = dll;
+            pfn_InitializeLibrary = (PFN_remixapi_InitializeLibrary) func;
+          } else {
+            FreeLibrary(dll);
+          }
+        }
+      }
+
+      // then try raw user-provided 'remixD3D9DllPath' file
+      if (!pfn_InitializeLibrary) {
+        // set LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR to search 
+        // dependency DLL-s in the folder of 'remixD3D9DllPath'
+        HMODULE dll = LoadLibraryExW(remixD3D9DllPath, NULL,
+                                     LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
+                                     LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+        if (dll) {
+          PROC func = GetProcAddress(dll, "remixapi_InitializeLibrary");
+          if (func) {
+            remixDll = dll;
+            pfn_InitializeLibrary = (PFN_remixapi_InitializeLibrary) func;
+          } else {
+            FreeLibrary(dll);
+          }
+        }
+      }
+
+      // at last, try to SetDllDirectory manually
+      if (!pfn_InitializeLibrary) {
+        wchar_t absoluteD3D9DllPath[MAX_PATH];
+        {
+          DWORD ret = GetFullPathNameW(remixD3D9DllPath, MAX_PATH, absoluteD3D9DllPath, NULL);
+          if (ret == 0) {
+            return REMIXAPI_ERROR_CODE_GET_FULL_PATH_NAME_FAILURE;
+          }
+        }
+        wchar_t parentDir[MAX_PATH];
+        {
+          int len = 0;
+          for (int i = 0; i < MAX_PATH; i++) {
+            if (absoluteD3D9DllPath[i] == '\0') {
+              break;
+            }
+            parentDir[i] = absoluteD3D9DllPath[i] == '/' ? '\\' : absoluteD3D9DllPath[i];
+            ++len;
+          }
+          if (len <= 0 || len >= MAX_PATH) {
+            return REMIXAPI_ERROR_CODE_INVALID_ARGUMENTS;
+          }
+          parentDir[len] = '\0';
+          for (int i = len - 1; i >= 0; --i) {
+            if (parentDir[i] == '\\') {
+              // remove one or more path separators
+              for (int k = i; k >= 0; --k) {
+                if (parentDir[k] == '\\') {
+                  parentDir[k] = '\0';
+                  continue;
+                }
+                break;
+              }
+              break;
+            }
+          }
+          if (parentDir[0] == '\0') {
+            return REMIXAPI_ERROR_CODE_INVALID_ARGUMENTS;
+          }
+        }
+
+        // save the previous value that is in SetDllDirectory
+        wchar_t dirToRestore[MAX_PATH];
+        {
+          DWORD len = GetDllDirectoryW(MAX_PATH, dirToRestore);
+          if (len > 0 && len < MAX_PATH - 1) {
+            dirToRestore[MAX_PATH - 1] = '\0';
+          }
+        }
+
+        {
+          BOOL s = SetDllDirectoryW(parentDir);
+          if (!s) {
+            return REMIXAPI_ERROR_CODE_SET_DLL_DIRECTORY_FAILURE;
+          }
+        }
+
+        HMODULE dll = LoadLibraryW(absoluteD3D9DllPath);
+        if (dll) {
+          PROC func = GetProcAddress(dll, "remixapi_InitializeLibrary");
+          if (func) {
+            remixDll = dll;
+            pfn_InitializeLibrary = (PFN_remixapi_InitializeLibrary) func;
+          } else {
+            FreeLibrary(dll);
+          }
+        }
+
+        // restore the previous value
+        {
+          SetDllDirectoryW(dirToRestore);
+        }
+      }
+    }
+
+    if (!remixDll) {
+      return REMIXAPI_ERROR_CODE_LOAD_LIBRARY_FAILURE;
+    }
+    if (!pfn_InitializeLibrary){
+      return REMIXAPI_ERROR_CODE_GET_PROC_ADDRESS_FAILURE;
+    }
+
+    remixapi_InitializeLibraryInfo info = {};
+    {
+      info.sType = REMIXAPI_STRUCT_TYPE_INITIALIZE_LIBRARY_INFO;
+      info.version = REMIXAPI_VERSION_MAKE(REMIXAPI_VERSION_MAJOR,
+                                           REMIXAPI_VERSION_MINOR,
+                                           REMIXAPI_VERSION_PATCH);
+    }
+    remixapi_Interface remixInterface = { nullptr };
+
+    remixapi_ErrorCode status = pfn_InitializeLibrary(&info, &remixInterface);
+    if (status != REMIXAPI_ERROR_CODE_SUCCESS) {
+      FreeLibrary(remixDll);
+      return status;
+    }
+
+    *out_remixInterface = remixInterface;
+    *out_remixDll = remixDll;
+    return status;
+  }
+
+  inline remixapi_ErrorCode REMIXAPI_CALL remixapi_lib_shutdownAndUnloadRemixDll(
+    remixapi_Interface* remixInterface,
+    HMODULE             remixDll
+  ) {
+    if (remixInterface == NULL || remixInterface->Shutdown == NULL) {
+      if (remixDll != NULL) {
+        FreeLibrary(remixDll);
+      }
+      return REMIXAPI_ERROR_CODE_INVALID_ARGUMENTS;
+    }
+
+    remixapi_ErrorCode status = remixInterface->Shutdown();
+    if (remixDll != NULL) {
+      FreeLibrary(remixDll);
+    }
+
+    remixapi_Interface nullInterface = { 0 };
+    *remixInterface = nullInterface;
+    return status;
+  }
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif // REMIX_C_H_

--- a/src/client/client_options.h
+++ b/src/client/client_options.h
@@ -62,6 +62,10 @@ namespace ClientOptions {
     return bridge_util::Config::getOption<bool>("client.enableDpiAwareness", true);
   }
 
+  inline bool getExposeRemixApi() {
+    return bridge_util::Config::getOption<bool>("client.exposeRemixApi", false);
+  }
+
   // If set, the space for data for dynamic buffer updates will be preallocated on data channel
   // and redundant copy will be avioded. However, because D3D applications are not obliged
   // to write the entire locked region this optimization is NOT considered safe and may

--- a/src/client/d3d9_device.cpp
+++ b/src/client/d3d9_device.cpp
@@ -46,6 +46,8 @@
 #include <wingdi.h>
 #include <assert.h>
 
+ #include "remix_api.h"
+
 #define GET_PRES_PARAM() (m_pSwapchain->getPresentationParameters())
 
 #define SetShaderConst(func, StartRegister, pConstantData, Count, size, currentUID) \
@@ -1119,6 +1121,10 @@ HRESULT Direct3DDevice9Ex_LSS<EnableSync>::EndScene() {
     if (gSceneState == SceneInProgress) {
       gSceneState = SceneEnded;
     }
+  }
+
+  if (remix_api::interfaceInitialized && remix_api::interfaceGameCallback) {
+    remix_api::interfaceGameCallback();
   }
 
   UID currentUID = 0;

--- a/src/client/meson.build
+++ b/src/client/meson.build
@@ -49,6 +49,7 @@ d3d9_src = files([
   'd3d9_volumetexture.cpp',
   'di_hook.cpp',
   'pch.cpp',
+  'remix_api.cpp',
   'remix_state.cpp',
 ])
 
@@ -80,6 +81,7 @@ d3d9_header = files([
   'framework.h',
   'lockable_buffer.h',
   'pch.h',
+  'remix_api.h',
   'remix_state.h',
   'resource.h',
   'shadow_map.h',
@@ -90,13 +92,14 @@ d3d9_def = files([
 ])
 
 detours_include_path = include_directories('../../ext/Detours/src')
+remixapi_include_path = include_directories('../api')
 
 thread_dep = dependency('threads')
 
 d3d9_dll = shared_library('d3d9', d3d9_src, d3d9_res, d3d9_header,
   sources             : [ bridge_version ],
   dependencies        : [ thread_dep, util_dep, lib_version, lib_version, lib_commCtrl, tracy_dep ],
-  include_directories : [ bridge_include_path, util_include_path, detours_include_path ],
+  include_directories : [ bridge_include_path, util_include_path, detours_include_path, remixapi_include_path ],
   install             : true,
   vs_module_defs      : 'd3d9_lss.def')
 

--- a/src/client/remix_api.cpp
+++ b/src/client/remix_api.cpp
@@ -1,0 +1,507 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "log/log.h"
+#include "util_bridgecommand.h"
+#include "util_devicecommand.h"
+#include "remix_api.h"
+
+
+#define SEND_FLOAT(MSG, V) \
+  (MSG).send_data((uint32_t) *(uint32_t*)(&(V)))
+
+#define SEND_FLOAT2D(MSG, V) \
+  SEND_FLOAT(MSG, (V).x); \
+  SEND_FLOAT(MSG, (V).y)
+
+#define SEND_FLOAT3D(MSG, V) \
+  SEND_FLOAT(MSG, (V).x); \
+  SEND_FLOAT(MSG, (V).y); \
+  SEND_FLOAT(MSG, (V).z)
+
+#define SEND_FLOAT4D(MSG, V) \
+  SEND_FLOAT(MSG, (V).x); \
+  SEND_FLOAT(MSG, (V).y); \
+  SEND_FLOAT(MSG, (V).z); \
+  SEND_FLOAT(MSG, (V).w)
+
+#define SEND_INT(MSG, T) \
+  (MSG).send_data((int32_t) (T))
+
+#define SEND_STYPE(MSG, T) \
+  (MSG).send_data((uint32_t) (T))
+
+#define SEND_U32(MSG, U32) \
+  (MSG).send_data((uint32_t) (U32))
+
+#define SEND_U64(MSG, U64) \
+  (MSG).send_data(sizeof(uint64_t), &(U64))
+
+#define SEND_PATH(MSG, PATH) \
+  (MSG).send_data((uint32_t)wcslen((PATH) ? (PATH) : L"") * sizeof(wchar_t), (PATH) ? (PATH) : L"")
+
+#define PULL_DATA(SIZE, NAME) \
+            uint32_t NAME##_len = DeviceBridge::get_data((void**)&(NAME)); \
+            assert(NAME##_len == 0 || (SIZE) == NAME##_len)
+
+namespace remix_api {
+  bool interfaceInitialized = false;
+  PFN_bridgeapi_RegisterEndSceneCallback interfaceGameCallback = nullptr;
+}
+
+namespace {
+  void BRIDGEAPI_CALL bridgeapi_DebugPrint(const char* text) {
+    if (text) {
+      ClientMessage c(Commands::Api_DebugPrint);
+      c.send_data((uint32_t) strlen(text), text);
+    }
+  }
+
+  uint64_t BRIDGEAPI_CALL bridgeapi_CreateOpaqueMaterial(const x86::remixapi_MaterialInfo* info, const x86::remixapi_MaterialInfoOpaqueEXT* ext, const x86::remixapi_MaterialInfoOpaqueSubsurfaceEXT* ext_ss) {
+    UID currentUID = 0;
+    {
+      ClientMessage c(Commands::Api_CreateOpaqueMaterial);
+      currentUID = c.get_uid();
+
+      // MaterialInfo
+      SEND_STYPE(c, info->sType);
+      SEND_U64(c, info->hash);
+      SEND_PATH(c, info->albedoTexture);
+      SEND_PATH(c, info->normalTexture);
+      SEND_PATH(c, info->tangentTexture);
+      SEND_PATH(c, info->emissiveTexture);
+      SEND_FLOAT(c, info->emissiveIntensity);
+      SEND_FLOAT3D(c, info->emissiveColorConstant);
+      c.send_data((uint8_t) info->spriteSheetRow);
+      c.send_data((uint8_t) info->spriteSheetCol);
+      c.send_data((uint8_t) info->spriteSheetFps);
+      c.send_data((uint8_t) info->filterMode);
+      c.send_data((uint8_t) info->wrapModeU);
+      c.send_data((uint8_t) info->wrapModeV);
+
+      // MaterialInfoOpaqueEXT
+      SEND_STYPE(c, ext->sType);
+      SEND_PATH(c, ext->roughnessTexture);
+      SEND_PATH(c, ext->metallicTexture);
+      SEND_FLOAT(c, ext->anisotropy);
+      SEND_FLOAT3D(c, ext->albedoConstant);
+      SEND_FLOAT(c, ext->opacityConstant);
+      SEND_FLOAT(c, ext->roughnessConstant);
+      SEND_FLOAT(c, ext->metallicConstant);
+      SEND_U32(c, ext->thinFilmThickness_hasvalue);
+      SEND_FLOAT(c, ext->thinFilmThickness_value);
+      SEND_U32(c, ext->alphaIsThinFilmThickness);
+      SEND_PATH(c, ext->heightTexture);
+      SEND_FLOAT(c, ext->heightTextureStrength);
+      SEND_U32(c, ext->useDrawCallAlphaState); // If true, InstanceInfoBlendEXT is used as a source for alpha state
+      SEND_U32(c, ext->blendType_hasvalue);
+      SEND_INT(c, ext->blendType_value);
+      SEND_U32(c, ext->invertedBlend);
+      SEND_INT(c, ext->alphaTestType);
+      c.send_data((uint8_t) ext->alphaReferenceValue);
+
+      const x86::remixapi_Bool has_ss = ext_ss ? TRUE : FALSE;
+      SEND_U32(c, has_ss);
+
+      if (ext_ss) {
+        // MaterialInfoOpaqueSubsurfaceEXT
+        SEND_STYPE(c, ext_ss->sType);
+        SEND_PATH(c, ext_ss->subsurfaceTransmittanceTexture);
+        SEND_PATH(c, ext_ss->subsurfaceThicknessTexture);
+        SEND_PATH(c, ext_ss->subsurfaceSingleScatteringAlbedoTexture);
+        SEND_FLOAT3D(c, ext_ss->subsurfaceTransmittanceColor);
+        SEND_FLOAT(c, ext_ss->subsurfaceMeasurementDistance);
+        SEND_FLOAT3D(c, ext_ss->subsurfaceSingleScatteringAlbedo);
+        SEND_FLOAT(c, ext_ss->subsurfaceVolumetricAnisotropy);
+      }
+    }
+
+    WAIT_FOR_SERVER_RESPONSE("CreateMaterial()", 0, currentUID);
+    uint64_t* result = nullptr;
+    PULL_DATA(sizeof(uint64_t), result);
+    DeviceBridge::pop_front();
+    return *result;
+  }
+
+  uint64_t BRIDGEAPI_CALL bridgeapi_CreateTranslucentMaterial(const x86::remixapi_MaterialInfo* info, const x86::remixapi_MaterialInfoTranslucentEXT* ext) {
+    UID currentUID = 0;
+    {
+      ClientMessage c(Commands::Api_CreateTranslucentMaterial);
+      currentUID = c.get_uid();
+
+      // MaterialInfo
+      SEND_STYPE(c, info->sType);
+      SEND_U64(c, info->hash);
+      SEND_PATH(c, info->albedoTexture);
+      SEND_PATH(c, info->normalTexture);
+      SEND_PATH(c, info->tangentTexture);
+      SEND_PATH(c, info->emissiveTexture);
+      SEND_FLOAT(c, info->emissiveIntensity);
+      SEND_FLOAT3D(c, info->emissiveColorConstant);
+      c.send_data((uint8_t) info->spriteSheetRow);
+      c.send_data((uint8_t) info->spriteSheetCol);
+      c.send_data((uint8_t) info->spriteSheetFps);
+      c.send_data((uint8_t) info->filterMode);
+      c.send_data((uint8_t) info->wrapModeU);
+      c.send_data((uint8_t) info->wrapModeV);
+
+      // MaterialInfoTranslucentEXT
+      SEND_STYPE(c, ext->sType);
+      SEND_PATH(c, ext->transmittanceTexture);
+      SEND_FLOAT(c, ext->refractiveIndex);
+      SEND_FLOAT3D(c, ext->transmittanceColor);
+      SEND_FLOAT(c, ext->transmittanceMeasurementDistance);
+      SEND_U32(c, ext->thinWallThickness_hasvalue);
+      SEND_FLOAT(c, ext->thinWallThickness_value);
+      SEND_U32(c, ext->useDiffuseLayer);
+    }
+
+    WAIT_FOR_SERVER_RESPONSE("CreateMaterial()", 0, currentUID);
+    uint64_t* result = nullptr;
+    PULL_DATA(sizeof(uint64_t), result);
+    DeviceBridge::pop_front();
+    return *result;
+  }
+
+  uint64_t BRIDGEAPI_CALL bridgeapi_CreatePortalMaterial(const x86::remixapi_MaterialInfo* info, const x86::remixapi_MaterialInfoPortalEXT* ext) {
+    UID currentUID = 0;
+    {
+      ClientMessage c(Commands::Api_CreatePortalMaterial);
+      currentUID = c.get_uid();
+
+      // MaterialInfo
+      SEND_STYPE(c, info->sType);
+      SEND_U64(c, info->hash);
+      SEND_PATH(c, info->albedoTexture);
+      SEND_PATH(c, info->normalTexture);
+      SEND_PATH(c, info->tangentTexture);
+      SEND_PATH(c, info->emissiveTexture);
+      SEND_FLOAT(c, info->emissiveIntensity);
+      SEND_FLOAT3D(c, info->emissiveColorConstant);
+      c.send_data((uint8_t) info->spriteSheetRow);
+      c.send_data((uint8_t) info->spriteSheetCol);
+      c.send_data((uint8_t) info->spriteSheetFps);
+      c.send_data((uint8_t) info->filterMode);
+      c.send_data((uint8_t) info->wrapModeU);
+      c.send_data((uint8_t) info->wrapModeV);
+
+      // MaterialInfoPortalEXT
+      SEND_STYPE(c, ext->sType);
+      c.send_data((uint8_t) ext->rayPortalIndex);
+      SEND_FLOAT(c, ext->rotationSpeed);
+    }
+
+    WAIT_FOR_SERVER_RESPONSE("CreateMaterial()", 0, currentUID);
+    uint64_t* result = nullptr;
+    PULL_DATA(sizeof(uint64_t), result);
+    DeviceBridge::pop_front();
+    return *result;
+  }
+
+  void BRIDGEAPI_CALL bridgeapi_DestroyMaterial(uint64_t handle) {
+    ClientMessage c(Commands::Api_DestroyMaterial);
+    SEND_U64(c, handle);
+  }
+
+  uint64_t BRIDGEAPI_CALL bridgeapi_CreateTriangleMesh(const x86::remixapi_MeshInfo* info) {
+    UID currentUID = 0;
+    {
+      ClientMessage c(Commands::Api_CreateTriangleMesh);
+      currentUID = c.get_uid();
+
+      // MeshInfo
+      SEND_STYPE(c, info->sType);
+      SEND_U64(c, info->hash);
+
+      // send each surface
+      SEND_U32(c, info->surfaces_count); // send surface count before sending the surfaces
+      for (uint32_t s = 0u; s < info->surfaces_count; s++) 
+      {
+        const auto& surf = info->surfaces_values[s];
+       
+        // send vertices of the current surface
+        SEND_U64(c, surf.vertices_count); // send vertex count before vertices
+        for (uint64_t v = 0u; v < surf.vertices_count; v++)
+        {
+          const auto& vert = surf.vertices_values[v];
+          SEND_FLOAT(c, vert.position[0]);
+          SEND_FLOAT(c, vert.position[1]);
+          SEND_FLOAT(c, vert.position[2]);
+          SEND_FLOAT(c, vert.normal[0]);
+          SEND_FLOAT(c, vert.normal[1]);
+          SEND_FLOAT(c, vert.normal[2]);
+          SEND_FLOAT(c, vert.texcoord[0]);
+          SEND_FLOAT(c, vert.texcoord[1]);
+          SEND_U32(c, vert.color);
+        }
+
+        // send indices of the current surface
+        SEND_U64(c, surf.indices_count); // send index count before indices
+        for (uint64_t i = 0u; i < surf.indices_count; i++) {
+          SEND_U32(c, surf.indices_values[i]);
+        }
+
+        SEND_U32(c, surf.skinning_hasvalue);
+        // # TODO skinning
+
+        // using remixapi_MaterialHandle is unpractical and kinda unsafe because its only 4 bytes <here> (ptr)
+        // so user would have to send an actual pointer instead of the uint64_t hash val 
+        SEND_U64(c, surf.material);
+      }
+    }
+
+    WAIT_FOR_SERVER_RESPONSE("CreateMesh()", 0, currentUID);
+    uint64_t* result = nullptr;
+    PULL_DATA(sizeof(uint64_t), result);
+    DeviceBridge::pop_front();
+    return *result;
+  }
+
+  void BRIDGEAPI_CALL bridgeapi_DestroyMesh(uint64_t handle) {
+    ClientMessage c(Commands::Api_DestroyMesh);
+    SEND_U64(c, handle);
+  }
+
+  void BRIDGEAPI_CALL bridgeapi_DrawMeshInstance(uint64_t handle, const x86::remixapi_Transform* t, x86::remixapi_Bool double_sided) {
+    ClientMessage c(Commands::Api_DrawMeshInstance);
+    SEND_U64(c, handle);
+    SEND_FLOAT(c, t->matrix[0][0]); SEND_FLOAT(c, t->matrix[0][1]); SEND_FLOAT(c, t->matrix[0][2]); SEND_FLOAT(c, t->matrix[0][3]);
+    SEND_FLOAT(c, t->matrix[1][0]); SEND_FLOAT(c, t->matrix[1][1]); SEND_FLOAT(c, t->matrix[1][2]); SEND_FLOAT(c, t->matrix[1][3]);
+    SEND_FLOAT(c, t->matrix[2][0]); SEND_FLOAT(c, t->matrix[2][1]); SEND_FLOAT(c, t->matrix[2][2]); SEND_FLOAT(c, t->matrix[2][3]);
+    SEND_U32(c, double_sided);
+  }
+
+  uint64_t BRIDGEAPI_CALL bridgeapi_CreateSphereLight(const x86::remixapi_LightInfo* info, const x86::remixapi_LightInfoSphereEXT* ext) {
+    UID currentUID = 0;
+    {
+      ClientMessage c(Commands::Api_CreateSphereLight);
+      currentUID = c.get_uid();
+
+      // LightInfo
+      SEND_STYPE(c, info->sType);
+      SEND_U64(c, info->hash);
+      SEND_FLOAT3D(c, info->radiance);
+
+      // LightInfoSphereEXT
+      SEND_STYPE(c, ext->sType);
+      SEND_FLOAT3D(c, ext->position);
+      SEND_FLOAT(c, ext->radius);
+      SEND_U32(c, ext->shaping_hasvalue);
+
+      if (ext->shaping_hasvalue) {
+        SEND_FLOAT3D(c, ext->shaping_value.direction);
+        SEND_FLOAT(c, ext->shaping_value.coneAngleDegrees);
+        SEND_FLOAT(c, ext->shaping_value.coneSoftness);
+        SEND_FLOAT(c, ext->shaping_value.focusExponent);
+      }
+    }
+
+    WAIT_FOR_SERVER_RESPONSE("CreateLight()", 0, currentUID);
+    uint64_t* result = nullptr;
+    PULL_DATA(sizeof(uint64_t), result);
+    DeviceBridge::pop_front();
+    return *result;
+  }
+
+  uint64_t BRIDGEAPI_CALL bridgeapi_CreateRectLight(const x86::remixapi_LightInfo* info, const x86::remixapi_LightInfoRectEXT* ext) {
+    UID currentUID = 0;
+    {
+      ClientMessage c(Commands::Api_CreateRectLight);
+      currentUID = c.get_uid();
+
+      // LightInfo
+      SEND_STYPE(c, info->sType);
+      SEND_U64(c, info->hash);
+      SEND_FLOAT3D(c, info->radiance);
+
+      // LightInfoRectEXT
+      SEND_STYPE(c, ext->sType);
+      SEND_FLOAT3D(c, ext->position);
+      SEND_FLOAT3D(c, ext->xAxis);
+      SEND_FLOAT(c, ext->xSize);
+      SEND_FLOAT3D(c, ext->yAxis);
+      SEND_FLOAT(c, ext->ySize);
+      SEND_FLOAT3D(c, ext->direction);
+      SEND_U32(c, ext->shaping_hasvalue);
+
+      if (ext->shaping_hasvalue) {
+        SEND_FLOAT3D(c, ext->shaping_value.direction);
+        SEND_FLOAT(c, ext->shaping_value.coneAngleDegrees);
+        SEND_FLOAT(c, ext->shaping_value.coneSoftness);
+        SEND_FLOAT(c, ext->shaping_value.focusExponent);
+      }
+    }
+
+    WAIT_FOR_SERVER_RESPONSE("CreateLight()", 0, currentUID);
+    uint64_t* result = nullptr;
+    PULL_DATA(sizeof(uint64_t), result);
+    DeviceBridge::pop_front();
+    return *result;
+  }
+
+  uint64_t BRIDGEAPI_CALL bridgeapi_CreateDiscLight(const x86::remixapi_LightInfo* info, const x86::remixapi_LightInfoDiskEXT* ext) {
+    UID currentUID = 0;
+    {
+      ClientMessage c(Commands::Api_CreateDiskLight);
+      currentUID = c.get_uid();
+
+      // LightInfo
+      SEND_STYPE(c, info->sType);
+      SEND_U64(c, info->hash);
+      SEND_FLOAT3D(c, info->radiance);
+
+      // LightInfoDiskEXT
+      SEND_STYPE(c, ext->sType);
+      SEND_FLOAT3D(c, ext->position);
+      SEND_FLOAT3D(c, ext->xAxis);
+      SEND_FLOAT(c, ext->xRadius);
+      SEND_FLOAT3D(c, ext->yAxis);
+      SEND_FLOAT(c, ext->yRadius);
+      SEND_FLOAT3D(c, ext->direction);
+      SEND_U32(c, ext->shaping_hasvalue);
+
+      if (ext->shaping_hasvalue) {
+        SEND_FLOAT3D(c, ext->shaping_value.direction);
+        SEND_FLOAT(c, ext->shaping_value.coneAngleDegrees);
+        SEND_FLOAT(c, ext->shaping_value.coneSoftness);
+        SEND_FLOAT(c, ext->shaping_value.focusExponent);
+      }
+    }
+
+    WAIT_FOR_SERVER_RESPONSE("CreateLight()", 0, currentUID);
+    uint64_t* result = nullptr;
+    PULL_DATA(sizeof(uint64_t), result);
+    DeviceBridge::pop_front();
+    return *result;
+  }
+
+  uint64_t BRIDGEAPI_CALL bridgeapi_CreateCylinderLight(const x86::remixapi_LightInfo* info, const x86::remixapi_LightInfoCylinderEXT* ext) {
+    UID currentUID = 0;
+    {
+      ClientMessage c(Commands::Api_CreateCylinderLight);
+      currentUID = c.get_uid();
+
+      // LightInfo
+      SEND_STYPE(c, info->sType);
+      SEND_U64(c, info->hash);
+      SEND_FLOAT3D(c, info->radiance);
+
+      // LightInfoCylinderEXT
+      SEND_STYPE(c, ext->sType);
+      SEND_FLOAT3D(c, ext->position);
+      SEND_FLOAT(c, ext->radius);
+      SEND_FLOAT3D(c, ext->axis);
+      SEND_FLOAT(c, ext->axisLength);
+    }
+
+    WAIT_FOR_SERVER_RESPONSE("CreateLight()", 0, currentUID);
+    uint64_t* result = nullptr;
+    PULL_DATA(sizeof(uint64_t), result);
+    DeviceBridge::pop_front();
+    return *result;
+  }
+
+  uint64_t BRIDGEAPI_CALL bridgeapi_CreateDistantLight(const x86::remixapi_LightInfo* info, const x86::remixapi_LightInfoDistantEXT* ext) {
+    UID currentUID = 0;
+    {
+      ClientMessage c(Commands::Api_CreateDistantLight);
+      currentUID = c.get_uid();
+
+      // LightInfo
+      SEND_STYPE(c, info->sType);
+      SEND_U64(c, info->hash);
+      SEND_FLOAT3D(c, info->radiance);
+
+      // LightInfoDistantEXT
+      SEND_STYPE(c, ext->sType);
+      SEND_FLOAT3D(c, ext->direction);
+      SEND_FLOAT(c, ext->angularDiameterDegrees);
+    }
+
+    WAIT_FOR_SERVER_RESPONSE("CreateLight()", 0, currentUID);
+    uint64_t* result = nullptr;
+    PULL_DATA(sizeof(uint64_t), result);
+    DeviceBridge::pop_front();
+    return *result;
+  }
+
+  void BRIDGEAPI_CALL bridgeapi_DestroyLight(uint64_t handle) {
+    ClientMessage c(Commands::Api_DestroyLight);
+    SEND_U64(c, handle);
+  }
+
+  void BRIDGEAPI_CALL bridgeapi_DrawLightInstance(uint64_t handle) {
+    ClientMessage c(Commands::Api_DrawLightInstance);
+    SEND_U64(c, handle);
+  }
+
+  void BRIDGEAPI_CALL bridgeapi_SetConfigVariable(const char* var, const char* value) {
+    if (var && value)
+    {
+      ClientMessage c(Commands::Api_SetConfigVariable);
+      c.send_data((uint32_t) strlen(var), var);
+      c.send_data((uint32_t) strlen(value), value);
+    }
+  }
+
+  void BRIDGEAPI_CALL bridgeapi_RegisterDevice() {
+    ClientMessage c(Commands::Api_RegisterDevice);
+  }
+
+  BRIDGE_API void bridgeapi_RegisterEndSceneCallback(PFN_bridgeapi_RegisterEndSceneCallback callback) {
+    remix_api::interfaceGameCallback = callback;
+  }
+
+  extern "C" {
+    BRIDGE_API BRIDGEAPI_ErrorCode __cdecl bridgeapi_InitFuncs(bridgeapi_Interface* out_result) {
+      if (!out_result) {
+        return BRIDGEAPI_ERROR_CODE_INVALID_ARGUMENTS;
+      }
+      auto interf = bridgeapi_Interface {};
+      {
+        interf.DebugPrint = bridgeapi_DebugPrint;
+        interf.CreateOpaqueMaterial = bridgeapi_CreateOpaqueMaterial;
+        interf.CreateTranslucentMaterial = bridgeapi_CreateTranslucentMaterial;
+        interf.CreatePortalMaterial = bridgeapi_CreatePortalMaterial;
+        interf.DestroyMaterial = bridgeapi_DestroyMaterial;
+        interf.CreateTriangleMesh = bridgeapi_CreateTriangleMesh;
+        interf.DestroyMesh = bridgeapi_DestroyMesh;
+        interf.DrawMeshInstance = bridgeapi_DrawMeshInstance;
+        interf.CreateSphereLight = bridgeapi_CreateSphereLight;
+        interf.CreateRectLight = bridgeapi_CreateRectLight;
+        interf.CreateDiskLight = bridgeapi_CreateDiscLight;
+        interf.CreateCylinderLight = bridgeapi_CreateCylinderLight;
+        interf.CreateDistantLight = bridgeapi_CreateDistantLight;
+        interf.DestroyLight = bridgeapi_DestroyLight;
+        interf.DrawLightInstance = bridgeapi_DrawLightInstance;
+        interf.SetConfigVariable = bridgeapi_SetConfigVariable;
+        interf.RegisterDevice = bridgeapi_RegisterDevice;
+        interf.RegisterEndSceneCallback = bridgeapi_RegisterEndSceneCallback;
+      }
+
+      *out_result = interf;
+      remix_api::interfaceInitialized = true;
+
+      return BRIDGEAPI_ERROR_CODE_SUCCESS;
+    }
+  }
+}

--- a/src/client/remix_api.h
+++ b/src/client/remix_api.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+#pragma once
+
+#include "remix_api/bridge_c.h"
+
+namespace remix_api {
+  extern bool interfaceInitialized;
+  extern PFN_bridgeapi_RegisterEndSceneCallback interfaceGameCallback;
+}

--- a/src/server/meson.build
+++ b/src/server/meson.build
@@ -44,11 +44,13 @@ server_resource = windows.compile_resources('NvRemixBridge.rc',
 	depend_files : ['NvRemixBridge.ico']
 )
 
+remixapi_include_path = include_directories('../api')
+
 server_exe = executable('NvRemixBridge', server_src, server_header, server_version, server_resource,
 sources             : [ bridge_version ],
 build_by_default    : (cpu_family == 'x86_64') ? true : false,
 dependencies        : [ thread_dep, util_dep, lib_version, tracy_dep ],
-include_directories : [ bridge_include_path, util_include_path ],
+include_directories : [ bridge_include_path, util_include_path, remixapi_include_path ],
 win_subsystem       : 'windows')
 
 

--- a/src/server/module_processing.h
+++ b/src/server/module_processing.h
@@ -2,4 +2,16 @@
 
 #include <atomic>
 
+#include "remix_api/remix_c.h"
+#include <mutex>
+
 void processModuleCommandQueue(std::atomic<bool>* const bSignalEnd);
+
+namespace remix_api {
+  extern remixapi_Interface g_remix;
+  extern bool g_remix_initialized;
+  extern HMODULE g_remix_dll;
+  extern IDirect3DDevice9Ex* g_device;
+  extern std::mutex g_device_mutex;
+  extern IDirect3DDevice9Ex* getDevice();
+}

--- a/src/util/util_commands.h
+++ b/src/util/util_commands.h
@@ -28,7 +28,7 @@
 
 namespace Commands {
   // The complete set of D3D9 interfaces
-  enum D3D9Command: uint16_t {
+  enum D3D9Command : uint16_t {
     Bridge_Terminate = std::numeric_limits<uint16_t>::max(),
     Bridge_Invalid = 0,
     Bridge_Syn,
@@ -37,6 +37,24 @@ namespace Commands {
     Bridge_Any,
     Bridge_Response,
     Bridge_DebugMessage,
+
+    Api_DebugPrint,
+    Api_CreateOpaqueMaterial,
+    Api_CreateTranslucentMaterial,
+    Api_CreatePortalMaterial,
+    Api_DestroyMaterial,
+    Api_CreateTriangleMesh,
+    Api_DestroyMesh,
+    Api_DrawMeshInstance,
+    Api_CreateSphereLight,
+    Api_CreateRectLight,
+    Api_CreateDiskLight,
+    Api_CreateCylinderLight,
+    Api_CreateDistantLight,
+    Api_DestroyLight,
+    Api_DrawLightInstance,
+    Api_SetConfigVariable,
+    Api_RegisterDevice,
 
     Bridge_SharedHeap_AddSeg,
     Bridge_SharedHeap_Alloc,
@@ -463,6 +481,24 @@ namespace Commands {
     case Bridge_Any: return "Any";
     case Bridge_Response: return "Response";
     case Bridge_DebugMessage: return "DebugMessage";
+
+    case Api_DebugPrint: return "ApiDebugPrint";
+    case Api_CreateOpaqueMaterial: return "ApiCreateOpaqueMaterial";
+    case Api_CreateTranslucentMaterial: return "ApiCreateTranslucentMaterial";
+    case Api_CreatePortalMaterial: return "ApiCreatePortalMaterial";
+    case Api_DestroyMaterial: return "ApiDestroyMaterial";
+    case Api_CreateTriangleMesh: return "ApiCreateTriangleMesh";
+    case Api_DestroyMesh: return "ApiDestroyMesh";
+    case Api_DrawMeshInstance: return "ApiDrawMeshInstance";
+    case Api_CreateSphereLight: return "ApiCreateSphereLight";
+    case Api_CreateRectLight: return "ApiCreateRectLight";
+    case Api_CreateDiskLight: return "ApiCreateDiskLight";
+    case Api_CreateCylinderLight: return "ApiCreateCylinderLight";
+    case Api_CreateDistantLight: return "ApiCreateDistantLight";
+    case Api_DestroyLight: return "ApiDestroyLight";
+    case Api_DrawLightInstance: return "DrawLightInstance";
+    case Api_SetConfigVariable: return "ApiSetConfigVariable";
+    case Api_RegisterDevice: return "ApiRegisterDevice";
 
     case Bridge_SharedHeap_AddSeg: return "SharedHeap_AddSeg";
     case Bridge_SharedHeap_Alloc: return "SharedHeap_Alloc";


### PR DESCRIPTION
This PR adds a intermediary api called ~~`BridgeApi`~~ to the bridge that allows x86 games to use parts of the x64 remix-runtime api.

### Overview:
- the client implements ~~BridgeApi~~ and sends the data of received api calls to the server [client/bridge_api.cpp](https://github.com/xoxor4d/bridge-remix/blob/feature/bridge-api-squashed/src/client/bridge_api.cpp)
- the server assembles the necessary RemixApi structs and calls the appropriate RemixApi functions [server/main.cpp](https://github.com/xoxor4d/bridge-remix/blob/a874b5dea53843f5943b88c575a8ee63fb2370ec/src/server/main.cpp#L2710)

### Behavior on init:
- [server/module_processing.cpp](https://github.com/xoxor4d/bridge-remix/blob/a874b5dea53843f5943b88c575a8ee63fb2370ec/src/server/module_processing.cpp#L416) grab the device pointer used to initialize the RemixApi in `CreateDevice` / `CreateDeviceEx`
- [server/main.cpp](https://github.com/xoxor4d/bridge-remix/blob/a874b5dea53843f5943b88c575a8ee63fb2370ec/src/server/main.cpp#L3343) initialize the RemixApi in `InitializeD3D` if client option `getEnableBridgeApi()` is true by calling `remixapi_lib_loadRemixDllAndInitialize` with the optained device pointer

### Usage:
- Using ~~BridgeApi~~ requires the user to be internal (dll/asi injection or by other means - requires game process access)
- Client option `client.exposeRemixApi` `true`
- Include [bridge_c.h](https://github.com/xoxor4d/bridge-remix/blob/feature/bridge-api-squashed/src/api/bridge_api/bridge_c.h) and a predefined macro:
```cpp
#define BRIDGE_API_IMPORT
#include "bridge_c.h"
```
<br>

- Initialize the api:
```cpp
// make sure that the bridge had enough time to create a device before you call the following
const auto status = bridgeapi_initialize(&bridge);
if (status == BRIDGEAPI_ERROR_CODE_SUCCESS)
{
  if (bridge.initialized)
  {
    bridge.RegisterDevice();
  }
}
```
<br>

- If no game render logic is hooked (triggered once per frame) or if the dll/asi has to be game agnostic, a callback can be registered that triggers when [`device->EndScene`](https://github.com/xoxor4d/bridge-remix/blob/a874b5dea53843f5943b88c575a8ee63fb2370ec/src/client/d3d9_device.cpp#L1126) is called:
```cpp
void on_endscene()
{
  bridge.DrawLightInstance(my_light_handle);
}

// somewhere after the api was initialized
bridge.RegisterEndSceneCallback(on_endscene);
```

### Notes:
- ~~I've set client option `client.exposeRemixApi` to `true` by default~~ (now false by default)

- I'm using a mutex to get the device [here](https://github.com/xoxor4d/bridge-remix/blob/a874b5dea53843f5943b88c575a8ee63fb2370ec/src/server/module_processing.cpp#L88). (I don't have much experience working with threads -> not sure if correct)

- I've directly included `remix_c.h` from `dxvk-remix` (should be made a dependency that's pulled?)

- There is no RemixApi version check nor does `bridge_c.h` expose any version

- Sending `const char*` or `wchar_t*` via rpc can result in the string no longer having the null terminator in the correct location. This can lead to strings with "junk data" attached to them. The returned length/size is correct tho. This also happens for `Bridge_DebugMessage`. This leads to special handling in every api case in `server/main.cpp` that`s using strings:

  - [`Api_DebugPrint`](https://github.com/xoxor4d/bridge-remix/blob/a874b5dea53843f5943b88c575a8ee63fb2370ec/src/server/main.cpp#L2714) using `std::string(data, length)` to construct a new string with the proper length
  -  [`Api_CreateOpaqueMaterial`](https://github.com/xoxor4d/bridge-remix/blob/a874b5dea53843f5943b88c575a8ee63fb2370ec/src/server/main.cpp#L2720) using `NVPULL_PATH` -> `std::wstring(data, length)` to construct a new wstring with the proper length

_____

#### Example usage of almost every feature:
- [iw3xo-dev/blob/feature/remix-api/src/components/modules/rtx/rtx_gui.cpp](https://github.com/xoxor4d/iw3xo-dev/blob/feature/remix-api/src/components/modules/rtx/rtx_gui.cpp) (search for `Developer`)
- [iw3xo-dev/blob/feature/remix-api/src/components/modules/rtx/rtx_api.cpp](https://github.com/xoxor4d/iw3xo-dev/blob/feature/remix-api/src/components/modules/rtx/rtx_api.cpp)